### PR TITLE
Hotfix comment

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -155,6 +155,16 @@ layout: table_wrappers
         {% endcapture %}
         {% if footer_custom != "" or site.last_edit_timestamp or site.gh_edit_link %}
           <hr>
+          {% if page.comment != false  %}
+            <script src="https://utteranc.es/client.js"
+          repo="devinan/devinan.github.io"
+          issue-term="pathname"
+          label="comments"
+          theme="github-light"
+          crossorigin="anonymous"
+          async>
+            </script>
+          {% endif %}
           <footer>
             {% if site.back_to_top %}
               <p><a href="#top" id="back-to-top">{{ site.back_to_top_text }}</a></p>

--- a/docs/tils/til.md
+++ b/docs/tils/til.md
@@ -4,6 +4,7 @@ title: TIL
 nav_order: 8
 has_children: true
 permalink: /docs/tils
+comment: false
 ---
 
 # TIL(today I learned)

--- a/index.md
+++ b/index.md
@@ -5,6 +5,7 @@ nav_order: 1
 description: "Welcome devinan Dev Blog."
 permalink: /
 last_modified_date: "Aug 07 2022 +0900"
+comment: false
 ---
 
 # Welcome to Devinan Dev Blog!


### PR DESCRIPTION
## 문제점

[til.md](https://devinan.github.io/docs/tils) 문서 댓글과 [August 07, 2022 문서](https://devinan.github.io/docs/tils/2022-08-07-test/)  댓글 연동 하여 어떤 포스트의 댓글인지 모릅니다.

## 발생이유

til 과 august-07-2022 문서는 서로 상하 관계를 이루고 있습니다.

즉, 하위문서인 august.. 에 댓글을 추가하면 상위 문서인 til에도 댓글을 볼수 있습니다.
그리고 상위 문서에 댓글을 추가하면 하위 문서에도 댓글이 생성됩니다.

## 해결 방법

til.md에 `comment: false` 추가하여 문서 연동 기능 해제 할 수 있습니다. #9 
